### PR TITLE
fix(stdio): resolve TypeScript export/import issues for stdio bridge classes

### DIFF
--- a/src/claude-code-bridge.ts
+++ b/src/claude-code-bridge.ts
@@ -83,8 +83,8 @@ async function main() {
     if (await checkServerHealth(DEFAULT_PORT)) {
       log(`Found existing server on port ${DEFAULT_PORT}`);
       // For Claude Code, we need to act as a stdio bridge to the HTTP server
-      const { StdioBridge } = await import('./stdio-bridge.js');
-      const bridge = new StdioBridge(DEFAULT_PORT);
+      const { StdioHttpBridge } = await import('./stdio-bridge.js');
+      const bridge = new StdioHttpBridge();
       await bridge.start();
       return;
     }
@@ -114,8 +114,8 @@ async function main() {
     }
 
     // Act as stdio bridge
-    const { StdioBridge } = await import('./stdio-bridge.js');
-    const bridge = new StdioBridge(DEFAULT_PORT);
+    const { StdioHttpBridge } = await import('./stdio-bridge.js');
+    const bridge = new StdioHttpBridge();
     await bridge.start();
   } catch (error) {
     log(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/stdio-bridge.ts
+++ b/src/stdio-bridge.ts
@@ -20,7 +20,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = dirname(__dirname);
 
-class StdioHttpBridge {
+export class StdioHttpBridge {
   private httpPort = 8125;
   private httpServerProcess: any = null;
   private server: Server;


### PR DESCRIPTION
## Summary
- Fixed TypeScript export/import issues in stdio bridge classes
- Added missing `export` keyword to `StdioHttpBridge` class in `stdio-bridge.ts`
- Updated import references from `StdioBridge` to `StdioHttpBridge` in `claude-code-bridge.ts`

## Changes
- `src/stdio-bridge.ts`: Added export to StdioHttpBridge class
- `src/claude-code-bridge.ts`: Fixed import name and constructor references

## Test Plan
- [x] TypeScript compilation passes
- [x] All tests pass (33/33)
- [x] NPM publication successful
- [x] Commit is signed with SSH key

## Context
These fixes were required for successful NPM publication of the stdio deployment features. The changes resolve TypeScript compilation errors that were blocking package publication.

## Security Notes
- All commits are signed with SSH key
- 3 low-severity Dependabot vulnerabilities detected on default branch (will address separately)